### PR TITLE
Fix docs

### DIFF
--- a/docs/.vitepress/theme/custom.scss
+++ b/docs/.vitepress/theme/custom.scss
@@ -1,4 +1,4 @@
-@use "../../../scss/functions/theme";
+@use "../../../src/scss/functions/theme";
 
 :root {
   --vp-c-brand: #{theme.get(primary, 700)};

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "sass": "rm -rf dist && sass scss:dist",
     "postcss": "postcss 'dist/**/*.css' --replace",
     "build": "npm run sass && npm run postcss",
+    "postbuild": "npm run docs:build",
     "release": "git add dist/. && standard-version -a",
     "prerelease": "npm run lint && npm run build",
     "docs:dev": "vitepress dev docs",


### PR DESCRIPTION
## Description

Changing the base paths for everything broke the docs site, and since the docs never build until they hit dev we never knew.

Fixed the issue _and_ added a postbuild script to build the docs site so every build test will include it.
