### PR TITLE
feat(function): handle transparent and other standard colors in theme.get()

### DIFF
--- a/src/scss/functions/_theme.scss
+++ b/src/scss/functions/_theme.scss
@@ -7,6 +7,22 @@
 
 // A function to get the specific theme shades.
 @function get($color, $shade) {
+  @if $shade == "transparent" or $color == "transparent" {
+    @return transparent;
+  }
+
+  @if $shade == "none" or $color == "none" {
+    @return none;
+  }
+
+  @if $shade == "inherit" or $color == "inherit" {
+    @return inherit;
+  }
+
+  @if $shade == "initial" or $color == "initial" {
+    @return initial;
+  }
+
   $color-map: map.get(color.$theme-active, $color);
   $value: map.get($color-map, $shade);
 


### PR DESCRIPTION
## Description

It was brought up that you can't map something like "transparent" to the button themes. That's sort of annoying, so the theme.get() function now handles that.
