### PR TITLE
fix: add var to calc'd values for accordion index

### DIFF
--- a/packages/core/src/scss/component/accordion/_index.scss
+++ b/packages/core/src/scss/component/accordion/_index.scss
@@ -27,8 +27,8 @@
         margin-top: calc(
           -1 *
             min(
-              #{$accordion-item-border-top-width},
-              #{$accordion-item-border-bottom-width}
+              var(#{$accordion-item-border-top-width}),
+              var(#{$accordion-item-border-bottom-width})
             )
         );
         /* stylelint-enable  scss/operator-no-newline-after */
@@ -159,10 +159,10 @@
         -1 *
           (
             min(
-                #{$accordion-item-border-top-width},
-                #{$accordion-item-border-bottom-width},
-                #{$accordion-item-border-left-width},
-                #{$accordion-item-border-right-width}
+                var(#{$accordion-item-border-top-width}),
+                var(#{$accordion-item-border-bottom-width}),
+                var(#{$accordion-item-border-left-width}),
+                var(#{$accordion-item-border-right-width})
               ) +
               #{focus.$focus-width}
           )


### PR DESCRIPTION
## Description
<!-- Why are you making this pull request? -->
compile breaks when trying to math variables that are not in a var()
## Related Issues
<!-- Please provide links to any related issues. -->
