### PR TITLE
fix: add overflow-wrap to prevent long text chains from breaking out

### DIFF
--- a/packages/core/src/scss/layout/container/_index.scss
+++ b/packages/core/src/scss/layout/container/_index.scss
@@ -172,6 +172,7 @@
       $container-feature-section-width [feature-end]
       $container-full-width-section-width [full-width-end];
     container-type: inline-size;
+    overflow-wrap: break-word;
 
     // Container components should span the full width of their parent container
     // and inherit the grid columns.


### PR DESCRIPTION
## Description
<!-- Why are you making this pull request? -->
Adds  overflow-wrap: break-word; to container class
## Related Issues
<!-- Please provide links to any related issues. -->
https://github.com/Graupl/graupl/issues/202