### PR TITLE
docs: rework spacing

### DIFF
--- a/docs/utilities/spacing.md
+++ b/docs/utilities/spacing.md
@@ -1,35 +1,35 @@
 <script setup>
   import { ref } from "vue";
 
-  const gap = ref("g-0");
-  const rowGap = ref("rg-0");
-  const columnGap = ref("cg-0");
-  const padding = ref("p-0");
-  const topPadding = ref("pt-0");
-  const rightPadding = ref("pr-0");
-  const bottomPadding = ref("pb-0");
-  const leftPadding = ref("pl-0");
-  const xPadding = ref("px-0");
-  const yPadding = ref("py-0");
-  const blockStartPadding = ref("pbs-0");
-  const blockEndPadding = ref("pbe-0");
-  const blockPadding = ref("pbse-0");
-  const inlineStartPadding = ref("pis-0");
-  const inlineEndPadding = ref("pie-0");
-  const inlinePadding = ref("pise-0");
-  const margin = ref("m-0");
-  const topMargin = ref("mt-0");
-  const rightMargin = ref("mr-0");
-  const bottomMargin = ref("mb-0");
-  const leftMargin = ref("ml-0");
-  const xMargin = ref("mx-0");
-  const yMargin = ref("my-0");
-  const blockStartMargin = ref("mbs-0");
-  const blockEndMargin = ref("mbe-0");
-  const blockMargin = ref("mbse-0");
-  const inlineStartMargin = ref("mis-0");
-  const inlineEndMargin = ref("mie-0");
-  const inlineMargin = ref("mise-0");
+  const gap = ref("g-auto");
+  const rowGap = ref("rg-auto");
+  const columnGap = ref("cg-auto");
+  const padding = ref("p-auto");
+  const paddingTop = ref("pt-auto");
+  const paddingRight = ref("pr-auto");
+  const paddingBottom = ref("pb-auto");
+  const paddingLeft = ref("pl-auto");
+  const paddingX = ref("px-auto");
+  const paddingY = ref("py-auto");
+  const paddingBlockStart = ref("pbs-auto");
+  const paddingBlockEnd = ref("pbe-auto");
+  const paddingBlock = ref("pbse-auto");
+  const paddingInlineStart = ref("pis-auto");
+  const paddingInlineEnd = ref("pie-auto");
+  const paddingInline = ref("pise-auto");
+  const margin = ref("m-auto");
+  const marginTop = ref("mt-auto");
+  const marginRight = ref("mr-auto");
+  const marginBottom = ref("mb-auto");
+  const marginLeft = ref("ml-auto");
+  const marginX = ref("mx-auto");
+  const marginY = ref("my-auto");
+  const marginBlockStart = ref("mbs-auto");
+  const marginBlockEnd = ref("mbe-auto");
+  const marginBlock = ref("mbse-auto");
+  const marginInlineStart = ref("mis-auto");
+  const marginInlineEnd = ref("mie-auto");
+  const marginInline = ref("mise-auto");
 </script>
 
 # Spacing Utilities
@@ -40,6 +40,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.g-auto` | gap | `auto` |
 | `.g-0` | gap | `var(--graupl-spacer-0)` |
 | `.g-1` | gap | `var(--graupl-spacer-1)` |
 | `.g-2` | gap | `var(--graupl-spacer-2)` |
@@ -51,18 +52,17 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.g-8` | gap | `var(--graupl-spacer-8)` |
 | `.g-9` | gap | `var(--graupl-spacer-9)` |
 | `.g-10` | gap | `var(--graupl-spacer-10)` |
-| `.g-auto` | row-gap | `auto`|
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div :class="`${gap} display-grid h-full`" style="grid-template-columns: repeat(3, min-content); grid-template-rows: auto;">
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
+      <div :class="`${gap} display-grid bg-tertiary-200 grid-cols-3 grid-rows-auto is-fit-content bs-fit-content`">
+        <div class="bordered border-primary-700 bg-primary-300 bs-7 is-7"></div>
+        <div class="bordered border-primary-700 bg-primary-300 bs-7 is-7"></div>
+        <div class="bordered border-primary-700 bg-primary-300 bs-7 is-7"></div>
+        <div class="bordered border-primary-700 bg-primary-300 bs-7 is-7"></div>
+        <div class="bordered border-primary-700 bg-primary-300 bs-7 is-7"></div>
+        <div class="bordered border-primary-700 bg-primary-300 bs-7 is-7"></div>
       </div>
     </div>
     <div class="example-classes">
@@ -72,17 +72,18 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
   <div class="input-group">
     <label for="select-gap">Gap property</label>
     <select id="select-gap" v-model="gap">
-      <option value="g-0">Spacer 0</option>
-      <option value="g-1">Spacer 1</option>
-      <option value="g-2">Spacer 2</option>
-      <option value="g-3">Spacer 3</option>
-      <option value="g-4">Spacer 4</option>
-      <option value="g-5">Spacer 5</option>
-      <option value="g-6">Spacer 6</option>
-      <option value="g-7">Spacer 7</option>
-      <option value="g-8">Spacer 8</option>
-      <option value="g-9">Spacer 9</option>
-      <option value="g-10">Spacer 10</option>
+      <option value="g-auto">Auto</option>
+      <option value="g-0">0</option>
+      <option value="g-1">1</option>
+      <option value="g-2">2</option>
+      <option value="g-3">3</option>
+      <option value="g-4">4</option>
+      <option value="g-5">5</option>
+      <option value="g-6">6</option>
+      <option value="g-7">7</option>
+      <option value="g-8">8</option>
+      <option value="g-9">9</option>
+      <option value="g-10">10</option>
     </select>
   </div>
 </div>
@@ -91,6 +92,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.rg-auto` | row-gap | `auto` |
 | `.rg-0` | row-gap | `var(--graupl-spacer-0)` |
 | `.rg-1` | row-gap | `var(--graupl-spacer-1)` |
 | `.rg-2` | row-gap | `var(--graupl-spacer-2)` |
@@ -102,18 +104,17 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.rg-8` | row-gap | `var(--graupl-spacer-8)` |
 | `.rg-9` | row-gap | `var(--graupl-spacer-9)` |
 | `.rg-10` | row-gap | `var(--graupl-spacer-10)` |
-| `.rg-auto` | row-gap | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div :class="`${rowGap} display-grid h-full`" style="grid-template-columns: repeat(3, min-content); grid-template-rows: auto;">
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
+      <div :class="`${rowGap} display-grid bg-tertiary-200 grid-cols-3 grid-rows-auto is-fit-content bs-fit-content`">
+        <div class="bordered border-primary-700 bg-primary-300 bs-7 is-7"></div>
+        <div class="bordered border-primary-700 bg-primary-300 bs-7 is-7"></div>
+        <div class="bordered border-primary-700 bg-primary-300 bs-7 is-7"></div>
+        <div class="bordered border-primary-700 bg-primary-300 bs-7 is-7"></div>
+        <div class="bordered border-primary-700 bg-primary-300 bs-7 is-7"></div>
+        <div class="bordered border-primary-700 bg-primary-300 bs-7 is-7"></div>
       </div>
     </div>
     <div class="example-classes">
@@ -121,19 +122,20 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
     </div>
   </div>
   <div class="input-group">
-    <label for="select-row-gap">Row Gap property</label>
+    <label for="select-row-gap">Row gap property</label>
     <select id="select-row-gap" v-model="rowGap">
-      <option value="rg-0">Spacer 0</option>
-      <option value="rg-1">Spacer 1</option>
-      <option value="rg-2">Spacer 2</option>
-      <option value="rg-3">Spacer 3</option>
-      <option value="rg-4">Spacer 4</option>
-      <option value="rg-5">Spacer 5</option>
-      <option value="rg-6">Spacer 6</option>
-      <option value="rg-7">Spacer 7</option>
-      <option value="rg-8">Spacer 8</option>
-      <option value="rg-9">Spacer 9</option>
-      <option value="rg-10">Spacer 10</option>
+      <option value="rg-auto">Auto</option>
+      <option value="rg-0">0</option>
+      <option value="rg-1">1</option>
+      <option value="rg-2">2</option>
+      <option value="rg-3">3</option>
+      <option value="rg-4">4</option>
+      <option value="rg-5">5</option>
+      <option value="rg-6">6</option>
+      <option value="rg-7">7</option>
+      <option value="rg-8">8</option>
+      <option value="rg-9">9</option>
+      <option value="rg-10">10</option>
     </select>
   </div>
 </div>
@@ -142,6 +144,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.cg-auto` | column-gap | `auto` |
 | `.cg-0` | column-gap | `var(--graupl-spacer-0)` |
 | `.cg-1` | column-gap | `var(--graupl-spacer-1)` |
 | `.cg-2` | column-gap | `var(--graupl-spacer-2)` |
@@ -153,18 +156,17 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.cg-8` | column-gap | `var(--graupl-spacer-8)` |
 | `.cg-9` | column-gap | `var(--graupl-spacer-9)` |
 | `.cg-10` | column-gap | `var(--graupl-spacer-10)` |
-| `.cg-auto` | column-gap | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div :class="`${columnGap} display-grid h-full`" style="grid-template-columns: repeat(3, min-content); grid-template-rows: auto;">
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
+      <div :class="`${columnGap} display-grid bg-tertiary-200 grid-cols-3 grid-rows-auto is-fit-content bs-fit-content`">
+        <div class="bordered border-primary-700 bg-primary-300 bs-7 is-7"></div>
+        <div class="bordered border-primary-700 bg-primary-300 bs-7 is-7"></div>
+        <div class="bordered border-primary-700 bg-primary-300 bs-7 is-7"></div>
+        <div class="bordered border-primary-700 bg-primary-300 bs-7 is-7"></div>
+        <div class="bordered border-primary-700 bg-primary-300 bs-7 is-7"></div>
+        <div class="bordered border-primary-700 bg-primary-300 bs-7 is-7"></div>
       </div>
     </div>
     <div class="example-classes">
@@ -172,19 +174,20 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
     </div>
   </div>
   <div class="input-group">
-    <label for="select-column-gap">Column Gap property</label>
+    <label for="select-column-gap">Column gap property</label>
     <select id="select-column-gap" v-model="columnGap">
-      <option value="cg-0">Spacer 0</option>
-      <option value="cg-1">Spacer 1</option>
-      <option value="cg-2">Spacer 2</option>
-      <option value="cg-3">Spacer 3</option>
-      <option value="cg-4">Spacer 4</option>
-      <option value="cg-5">Spacer 5</option>
-      <option value="cg-6">Spacer 6</option>
-      <option value="cg-7">Spacer 7</option>
-      <option value="cg-8">Spacer 8</option>
-      <option value="cg-9">Spacer 9</option>
-      <option value="cg-10">Spacer 10</option>
+      <option value="cg-auto">Auto</option>
+      <option value="cg-0">0</option>
+      <option value="cg-1">1</option>
+      <option value="cg-2">2</option>
+      <option value="cg-3">3</option>
+      <option value="cg-4">4</option>
+      <option value="cg-5">5</option>
+      <option value="cg-6">6</option>
+      <option value="cg-7">7</option>
+      <option value="cg-8">8</option>
+      <option value="cg-9">9</option>
+      <option value="cg-10">10</option>
     </select>
   </div>
 </div>
@@ -193,6 +196,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.p-auto` | padding | `auto` |
 | `.p-0` | padding | `var(--graupl-spacer-0)` |
 | `.p-1` | padding | `var(--graupl-spacer-1)` |
 | `.p-2` | padding | `var(--graupl-spacer-2)` |
@@ -204,15 +208,14 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.p-8` | padding | `var(--graupl-spacer-8)` |
 | `.p-9` | padding | `var(--graupl-spacer-9)` |
 | `.p-10` | padding | `var(--graupl-spacer-10)` |
-| `.p-auto` | padding | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 ${padding}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div :class="`bordered border-primary-700 bg-tertiary-200 ${padding}`">
+          <div class="bg-primary-300 bs-7 is-7"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
@@ -222,17 +225,18 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
   <div class="input-group">
     <label for="select-padding">Padding property</label>
     <select id="select-padding" v-model="padding">
-      <option value="p-0">Spacer 0</option>
-      <option value="p-1">Spacer 1</option>
-      <option value="p-2">Spacer 2</option>
-      <option value="p-5">Spacer 3</option>
-      <option value="p-4">Spacer 4</option>
-      <option value="p-5">Spacer 5</option>
-      <option value="p-6">Spacer 6</option>
-      <option value="p-7">Spacer 7</option>
-      <option value="p-8">Spacer 8</option>
-      <option value="p-9">Spacer 9</option>
-      <option value="p-10">Spacer 10</option>
+      <option value="p-auto">Auto</option>
+      <option value="p-0">0</option>
+      <option value="p-1">1</option>
+      <option value="p-2">2</option>
+      <option value="p-3">3</option>
+      <option value="p-4">4</option>
+      <option value="p-5">5</option>
+      <option value="p-6">6</option>
+      <option value="p-7">7</option>
+      <option value="p-8">8</option>
+      <option value="p-9">9</option>
+      <option value="p-10">10</option>
     </select>
   </div>
 </div>
@@ -242,6 +246,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.pt-auto` | padding-top | `auto` |
 | `.pt-0` | padding-top | `var(--graupl-spacer-0)` |
 | `.pt-1` | padding-top | `var(--graupl-spacer-1)` |
 | `.pt-2` | padding-top | `var(--graupl-spacer-2)` |
@@ -253,35 +258,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.pt-8` | padding-top | `var(--graupl-spacer-8)` |
 | `.pt-9` | padding-top | `var(--graupl-spacer-9)` |
 | `.pt-10` | padding-top | `var(--graupl-spacer-10)` |
-| `.pt-auto` | padding-top | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 px-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 px-5 ${topPadding}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 px-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div :class="`bordered border-primary-700 bg-tertiary-200 ${paddingTop}`">
+          <div class="bg-primary-300 bs-7 is-7"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ topPadding }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ paddingTop }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-top-padding">Top Padding property</label>
-    <select id="select-top-padding" v-model="topPadding">
-      <option value="pt-0">Spacer 0</option>
-      <option value="pt-1">Spacer 1</option>
-      <option value="pt-2">Spacer 2</option>
-      <option value="pt-3">Spacer 3</option>
-      <option value="pt-4">Spacer 4</option>
-      <option value="pt-5">Spacer 5</option>
-      <option value="pt-6">Spacer 6</option>
-      <option value="pt-7">Spacer 7</option>
-      <option value="pt-8">Spacer 8</option>
-      <option value="pt-9">Spacer 9</option>
-      <option value="pt-10">Spacer 10</option>
+    <label for="select-padding-top">Padding top property</label>
+    <select id="select-padding-top" v-model="paddingTop">
+      <option value="pt-auto">Auto</option>
+      <option value="pt-0">0</option>
+      <option value="pt-1">1</option>
+      <option value="pt-2">2</option>
+      <option value="pt-3">3</option>
+      <option value="pt-4">4</option>
+      <option value="pt-5">5</option>
+      <option value="pt-6">6</option>
+      <option value="pt-7">7</option>
+      <option value="pt-8">8</option>
+      <option value="pt-9">9</option>
+      <option value="pt-10">10</option>
     </select>
   </div>
 </div>
@@ -290,6 +295,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.pr-auto` | padding-right | `auto` |
 | `.pr-0` | padding-right | `var(--graupl-spacer-0)` |
 | `.pr-1` | padding-right | `var(--graupl-spacer-1)` |
 | `.pr-2` | padding-right | `var(--graupl-spacer-2)` |
@@ -301,35 +307,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.pr-8` | padding-right | `var(--graupl-spacer-8)` |
 | `.pr-9` | padding-right | `var(--graupl-spacer-9)` |
 | `.pr-10` | padding-right | `var(--graupl-spacer-10)` |
-| `.pr-auto` | padding-right | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 py-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 py-5 ${rightPadding}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 py-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div :class="`bordered border-primary-700 bg-tertiary-200 ${paddingRight}`">
+          <div class="bg-primary-300 bs-7 is-7"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ rightPadding }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ paddingRight }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-right-padding">right Padding property</label>
-    <select id="select-right-padding" v-model="rightPadding">
-      <option value="pr-0">Spacer 0</option>
-      <option value="pr-1">Spacer 1</option>
-      <option value="pr-2">Spacer 2</option>
-      <option value="pr-3">Spacer 3</option>
-      <option value="pr-4">Spacer 4</option>
-      <option value="pr-5">Spacer 5</option>
-      <option value="pr-6">Spacer 6</option>
-      <option value="pr-7">Spacer 7</option>
-      <option value="pr-8">Spacer 8</option>
-      <option value="pr-9">Spacer 9</option>
-      <option value="pr-10">Spacer 10</option>
+    <label for="select-padding-right">Padding right property</label>
+    <select id="select-padding-right" v-model="paddingRight">
+      <option value="pr-auto">Auto</option>
+      <option value="pr-0">0</option>
+      <option value="pr-1">1</option>
+      <option value="pr-2">2</option>
+      <option value="pr-3">3</option>
+      <option value="pr-4">4</option>
+      <option value="pr-5">5</option>
+      <option value="pr-6">6</option>
+      <option value="pr-7">7</option>
+      <option value="pr-8">8</option>
+      <option value="pr-9">9</option>
+      <option value="pr-10">10</option>
     </select>
   </div>
 </div>
@@ -338,6 +344,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.pb-auto` | padding-bottom | `auto` |
 | `.pb-0` | padding-bottom | `var(--graupl-spacer-0)` |
 | `.pb-1` | padding-bottom | `var(--graupl-spacer-1)` |
 | `.pb-2` | padding-bottom | `var(--graupl-spacer-2)` |
@@ -349,35 +356,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.pb-8` | padding-bottom | `var(--graupl-spacer-8)` |
 | `.pb-9` | padding-bottom | `var(--graupl-spacer-9)` |
 | `.pb-10` | padding-bottom | `var(--graupl-spacer-10)` |
-| `.pb-auto` | padding-bottom | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 px-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 px-5 ${bottomPadding}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 px-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div :class="`bordered border-primary-700 bg-tertiary-200 ${paddingBottom}`">
+          <div class="bg-primary-300 bs-7 is-7"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ bottomPadding }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ paddingBottom }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-bottom-padding">Bottom Padding property</label>
-    <select id="select-bottom-padding" v-model="bottomPadding">
-      <option value="pb-0">Spacer 0</option>
-      <option value="pb-1">Spacer 1</option>
-      <option value="pb-2">Spacer 2</option>
-      <option value="pb-3">Spacer 3</option>
-      <option value="pb-4">Spacer 4</option>
-      <option value="pb-5">Spacer 5</option>
-      <option value="pb-6">Spacer 6</option>
-      <option value="pb-7">Spacer 7</option>
-      <option value="pb-8">Spacer 8</option>
-      <option value="pb-9">Spacer 9</option>
-      <option value="pb-10">Spacer 10</option>
+    <label for="select-padding-bottom">Padding bottom property</label>
+    <select id="select-padding-bottom" v-model="paddingBottom">
+      <option value="pb-auto">Auto</option>
+      <option value="pb-0">0</option>
+      <option value="pb-1">1</option>
+      <option value="pb-2">2</option>
+      <option value="pb-3">3</option>
+      <option value="pb-4">4</option>
+      <option value="pb-5">5</option>
+      <option value="pb-6">6</option>
+      <option value="pb-7">7</option>
+      <option value="pb-8">8</option>
+      <option value="pb-9">9</option>
+      <option value="pb-10">10</option>
     </select>
   </div>
 </div>
@@ -386,6 +393,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.pl-auto` | padding-left | `auto` |
 | `.pl-0` | padding-left | `var(--graupl-spacer-0)` |
 | `.pl-1` | padding-left | `var(--graupl-spacer-1)` |
 | `.pl-2` | padding-left | `var(--graupl-spacer-2)` |
@@ -397,35 +405,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.pl-8` | padding-left | `var(--graupl-spacer-8)` |
 | `.pl-9` | padding-left | `var(--graupl-spacer-9)` |
 | `.pl-10` | padding-left | `var(--graupl-spacer-10)` |
-| `.pl-auto` | padding-left | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 py-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 py-5 ${leftPadding}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 py-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div :class="`bordered border-primary-700 bg-tertiary-200 ${paddingLeft}`">
+          <div class="bg-primary-300 bs-7 is-7"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ leftPadding }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ paddingLeft }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-left-padding">Left Padding property</label>
-    <select id="select-left-padding" v-model="leftPadding">
-      <option value="pl-0">Spacer 0</option>
-      <option value="pl-1">Spacer 1</option>
-      <option value="pl-2">Spacer 2</option>
-      <option value="pl-3">Spacer 3</option>
-      <option value="pl-4">Spacer 4</option>
-      <option value="pl-5">Spacer 5</option>
-      <option value="pl-6">Spacer 6</option>
-      <option value="pl-7">Spacer 7</option>
-      <option value="pl-8">Spacer 8</option>
-      <option value="pl-9">Spacer 9</option>
-      <option value="pl-10">Spacer 10</option>
+    <label for="select-padding-left">Padding left property</label>
+    <select id="select-padding-left" v-model="paddingLeft">
+      <option value="pl-auto">Auto</option>
+      <option value="pl-0">0</option>
+      <option value="pl-1">1</option>
+      <option value="pl-2">2</option>
+      <option value="pl-3">3</option>
+      <option value="pl-4">4</option>
+      <option value="pl-5">5</option>
+      <option value="pl-6">6</option>
+      <option value="pl-7">7</option>
+      <option value="pl-8">8</option>
+      <option value="pl-9">9</option>
+      <option value="pl-10">10</option>
     </select>
   </div>
 </div>
@@ -434,6 +442,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.px-auto` | padding-left, padding-right | `auto` |
 | `.px-0` | padding-left, padding-right | `var(--graupl-spacer-0)` |
 | `.px-1` | padding-left, padding-right | `var(--graupl-spacer-1)` |
 | `.px-2` | padding-left, padding-right | `var(--graupl-spacer-2)` |
@@ -445,35 +454,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.px-8` | padding-left, padding-right | `var(--graupl-spacer-8)` |
 | `.px-9` | padding-left, padding-right | `var(--graupl-spacer-9)` |
 | `.px-10` | padding-left, padding-right | `var(--graupl-spacer-10)` |
-| `.px-auto` | padding-left, padding-right | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 py-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 py-5 ${xPadding}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 py-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div :class="`bordered border-primary-700 bg-tertiary-200 ${paddingX}`">
+          <div class="bg-primary-300 bs-7 is-7"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ xPadding }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ paddingX }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-x-padding">X Padding property</label>
-    <select id="select-x-padding" v-model="xPadding">
-      <option value="px-0">Spacer 0</option>
-      <option value="px-1">Spacer 1</option>
-      <option value="px-2">Spacer 2</option>
-      <option value="px-3">Spacer 3</option>
-      <option value="px-4">Spacer 4</option>
-      <option value="px-5">Spacer 5</option>
-      <option value="px-6">Spacer 6</option>
-      <option value="px-7">Spacer 7</option>
-      <option value="px-8">Spacer 8</option>
-      <option value="px-9">Spacer 9</option>
-      <option value="px-10">Spacer 10</option>
+    <label for="select-padding-x">Padding X property</label>
+    <select id="select-padding-x" v-model="paddingX">
+      <option value="px-auto">Auto</option>
+      <option value="px-0">0</option>
+      <option value="px-1">1</option>
+      <option value="px-2">2</option>
+      <option value="px-3">3</option>
+      <option value="px-4">4</option>
+      <option value="px-5">5</option>
+      <option value="px-6">6</option>
+      <option value="px-7">7</option>
+      <option value="px-8">8</option>
+      <option value="px-9">9</option>
+      <option value="px-10">10</option>
     </select>
   </div>
 </div>
@@ -482,6 +491,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.py-auto` | padding-top, padding-bottom | `auto` |
 | `.py-0` | padding-top, padding-bottom | `var(--graupl-spacer-0)` |
 | `.py-1` | padding-top, padding-bottom | `var(--graupl-spacer-1)` |
 | `.py-2` | padding-top, padding-bottom | `var(--graupl-spacer-2)` |
@@ -493,35 +503,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.py-8` | padding-top, padding-bottom | `var(--graupl-spacer-8)` |
 | `.py-9` | padding-top, padding-bottom | `var(--graupl-spacer-9)` |
 | `.py-10` | padding-top, padding-bottom | `var(--graupl-spacer-10)` |
-| `.py-auto` | padding-top, padding-bottom | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 px-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 px-5 ${yPadding}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 px-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div :class="`bordered border-primary-700 bg-tertiary-200 ${paddingY}`">
+          <div class="bg-primary-300 bs-7 is-7"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ yPadding }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ paddingY }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-y-padding">Y Padding property</label>
-    <select id="select-y-padding" v-model="yPadding">
-      <option value="py-0">Spacer 0</option>
-      <option value="py-1">Spacer 1</option>
-      <option value="py-2">Spacer 2</option>
-      <option value="py-3">Spacer 3</option>
-      <option value="py-4">Spacer 4</option>
-      <option value="py-5">Spacer 5</option>
-      <option value="py-6">Spacer 6</option>
-      <option value="py-7">Spacer 7</option>
-      <option value="py-8">Spacer 8</option>
-      <option value="py-9">Spacer 9</option>
-      <option value="py-10">Spacer 10</option>
+    <label for="select-padding-y">Padding Y property</label>
+    <select id="select-padding-y" v-model="paddingY">
+      <option value="py-auto">Auto</option>
+      <option value="py-0">0</option>
+      <option value="py-1">1</option>
+      <option value="py-2">2</option>
+      <option value="py-3">3</option>
+      <option value="py-4">4</option>
+      <option value="py-5">5</option>
+      <option value="py-6">6</option>
+      <option value="py-7">7</option>
+      <option value="py-8">8</option>
+      <option value="py-9">9</option>
+      <option value="py-10">10</option>
     </select>
   </div>
 </div>
@@ -530,6 +540,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.pbs-auto` | padding-block-start | `auto` |
 | `.pbs-0` | padding-block-start | `var(--graupl-spacer-0)` |
 | `.pbs-1` | padding-block-start | `var(--graupl-spacer-1)` |
 | `.pbs-2` | padding-block-start | `var(--graupl-spacer-2)` |
@@ -541,35 +552,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.pbs-8` | padding-block-start | `var(--graupl-spacer-8)` |
 | `.pbs-9` | padding-block-start | `var(--graupl-spacer-9)` |
 | `.pbs-10` | padding-block-start | `var(--graupl-spacer-10)` |
-| `.pbs-auto` | padding-block-start | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 px-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 px-5 ${blockStartPadding}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 px-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div :class="`bordered border-primary-700 bg-tertiary-200 ${paddingBlockStart}`">
+          <div class="bg-primary-300 bs-7 is-7"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ blockStartPadding }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ paddingBlockStart }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-block-start-padding">Block Start Padding property</label>
-    <select id="select-block-start-padding" v-model="blockStartPadding">
-      <option value="pbs-0">Spacer 0</option>
-      <option value="pbs-1">Spacer 1</option>
-      <option value="pbs-2">Spacer 2</option>
-      <option value="pbs-3">Spacer 3</option>
-      <option value="pbs-4">Spacer 4</option>
-      <option value="pbs-5">Spacer 5</option>
-      <option value="pbs-6">Spacer 6</option>
-      <option value="pbs-7">Spacer 7</option>
-      <option value="pbs-8">Spacer 8</option>
-      <option value="pbs-9">Spacer 9</option>
-      <option value="pbs-10">Spacer 10</option>
+    <label for="select-padding-block-start">Padding block start property</label>
+    <select id="select-padding-block-start" v-model="paddingBlockStart">
+      <option value="pbs-auto">Auto</option>
+      <option value="pbs-0">0</option>
+      <option value="pbs-1">1</option>
+      <option value="pbs-2">2</option>
+      <option value="pbs-3">3</option>
+      <option value="pbs-4">4</option>
+      <option value="pbs-5">5</option>
+      <option value="pbs-6">6</option>
+      <option value="pbs-7">7</option>
+      <option value="pbs-8">8</option>
+      <option value="pbs-9">9</option>
+      <option value="pbs-10">10</option>
     </select>
   </div>
 </div>
@@ -579,6 +590,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.pbe-auto` | padding-block-end | `auto` |
 | `.pbe-0` | padding-block-end | `var(--graupl-spacer-0)` |
 | `.pbe-1` | padding-block-end | `var(--graupl-spacer-1)` |
 | `.pbe-2` | padding-block-end | `var(--graupl-spacer-2)` |
@@ -590,35 +602,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.pbe-8` | padding-block-end | `var(--graupl-spacer-8)` |
 | `.pbe-9` | padding-block-end | `var(--graupl-spacer-9)` |
 | `.pbe-10` | padding-block-end | `var(--graupl-spacer-10)` |
-| `.pbe-auto` | padding-block-end | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 px-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 px-5 ${blockEndPadding}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 px-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div :class="`bordered border-primary-700 bg-tertiary-200 ${paddingBlockEnd}`">
+          <div class="bg-primary-300 bs-7 is-7"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ blockEndPadding }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ paddingBlockEnd }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-block-end-padding">Block End Padding property</label>
-    <select id="select-block-end-padding" v-model="blockEndPadding">
-      <option value="pbe-0">Spacer 0</option>
-      <option value="pbe-1">Spacer 1</option>
-      <option value="pbe-2">Spacer 2</option>
-      <option value="pbe-3">Spacer 3</option>
-      <option value="pbe-4">Spacer 4</option>
-      <option value="pbe-5">Spacer 5</option>
-      <option value="pbe-6">Spacer 6</option>
-      <option value="pbe-7">Spacer 7</option>
-      <option value="pbe-8">Spacer 8</option>
-      <option value="pbe-9">Spacer 9</option>
-      <option value="pbe-10">Spacer 10</option>
+    <label for="select-padding-block-end">Padding block end property</label>
+    <select id="select-padding-block-end" v-model="paddingBlockEnd">
+      <option value="pbe-auto">Auto</option>
+      <option value="pbe-0">0</option>
+      <option value="pbe-1">1</option>
+      <option value="pbe-2">2</option>
+      <option value="pbe-3">3</option>
+      <option value="pbe-4">4</option>
+      <option value="pbe-5">5</option>
+      <option value="pbe-6">6</option>
+      <option value="pbe-7">7</option>
+      <option value="pbe-8">8</option>
+      <option value="pbe-9">9</option>
+      <option value="pbe-10">10</option>
     </select>
   </div>
 </div>
@@ -627,6 +639,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.pbse-auto` | padding-block | `auto` |
 | `.pbse-0` | padding-block | `var(--graupl-spacer-0)` |
 | `.pbse-1` | padding-block | `var(--graupl-spacer-1)` |
 | `.pbse-2` | padding-block | `var(--graupl-spacer-2)` |
@@ -638,35 +651,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.pbse-8` | padding-block | `var(--graupl-spacer-8)` |
 | `.pbse-9` | padding-block | `var(--graupl-spacer-9)` |
 | `.pbse-10` | padding-block | `var(--graupl-spacer-10)` |
-| `.pbse-auto` | padding-block | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 px-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 px-5 ${blockPadding}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 px-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div :class="`bordered border-primary-700 bg-tertiary-200 ${paddingBlock}`">
+          <div class="bg-primary-300 bs-7 is-7"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ blockPadding }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ paddingBlock }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-block-padding">Block Padding property</label>
-    <select id="select-block-padding" v-model="blockPadding">
-      <option value="pbse-0">Spacer 0</option>
-      <option value="pbse-1">Spacer 1</option>
-      <option value="pbse-2">Spacer 2</option>
-      <option value="pbse-3">Spacer 3</option>
-      <option value="pbse-4">Spacer 4</option>
-      <option value="pbse-5">Spacer 5</option>
-      <option value="pbse-6">Spacer 6</option>
-      <option value="pbse-7">Spacer 7</option>
-      <option value="pbse-8">Spacer 8</option>
-      <option value="pbse-9">Spacer 9</option>
-      <option value="pbse-10">Spacer 10</option>
+    <label for="select-padding-block">Padding block property</label>
+    <select id="select-padding-block" v-model="paddingBlock">
+      <option value="pbse-auto">Auto</option>
+      <option value="pbse-0">0</option>
+      <option value="pbse-1">1</option>
+      <option value="pbse-2">2</option>
+      <option value="pbse-3">3</option>
+      <option value="pbse-4">4</option>
+      <option value="pbse-5">5</option>
+      <option value="pbse-6">6</option>
+      <option value="pbse-7">7</option>
+      <option value="pbse-8">8</option>
+      <option value="pbse-9">9</option>
+      <option value="pbse-10">10</option>
     </select>
   </div>
 </div>
@@ -675,6 +688,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.pis-auto` | padding-inline-start | `auto` |
 | `.pis-0` | padding-inline-start | `var(--graupl-spacer-0)` |
 | `.pis-1` | padding-inline-start | `var(--graupl-spacer-1)` |
 | `.pis-2` | padding-inline-start | `var(--graupl-spacer-2)` |
@@ -686,35 +700,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.pis-8` | padding-inline-start | `var(--graupl-spacer-8)` |
 | `.pis-9` | padding-inline-start | `var(--graupl-spacer-9)` |
 | `.pis-10` | padding-inline-start | `var(--graupl-spacer-10)` |
-| `.pis-auto` | padding-inline-start | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 py-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 py-5 ${inlineStartPadding}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 py-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div :class="`bordered border-primary-700 bg-tertiary-200 ${paddingInlineStart}`">
+          <div class="bg-primary-300 bs-7 is-7"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ inlineStartPadding }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ paddingInlineStart }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-inline-start-padding">Inline Start Padding property</label>
-    <select id="select-inline-start-padding" v-model="inlineStartPadding">
-      <option value="pis-0">Spacer 0</option>
-      <option value="pis-1">Spacer 1</option>
-      <option value="pis-2">Spacer 2</option>
-      <option value="pis-3">Spacer 3</option>
-      <option value="pis-4">Spacer 4</option>
-      <option value="pis-5">Spacer 5</option>
-      <option value="pis-6">Spacer 6</option>
-      <option value="pis-7">Spacer 7</option>
-      <option value="pis-8">Spacer 8</option>
-      <option value="pis-9">Spacer 9</option>
-      <option value="pis-10">Spacer 10</option>
+    <label for="select-padding-inline-start">Padding inline start property</label>
+    <select id="select-padding-inline-start" v-model="paddingInlineStart">
+      <option value="pis-auto">Auto</option>
+      <option value="pis-0">0</option>
+      <option value="pis-1">1</option>
+      <option value="pis-2">2</option>
+      <option value="pis-3">3</option>
+      <option value="pis-4">4</option>
+      <option value="pis-5">5</option>
+      <option value="pis-6">6</option>
+      <option value="pis-7">7</option>
+      <option value="pis-8">8</option>
+      <option value="pis-9">9</option>
+      <option value="pis-10">10</option>
     </select>
   </div>
 </div>
@@ -723,6 +737,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.pie-auto` | padding-inline-end | `auto` |
 | `.pie-0` | padding-inline-end | `var(--graupl-spacer-0)` |
 | `.pie-1` | padding-inline-end | `var(--graupl-spacer-1)` |
 | `.pie-2` | padding-inline-end | `var(--graupl-spacer-2)` |
@@ -734,35 +749,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.pie-8` | padding-inline-end | `var(--graupl-spacer-8)` |
 | `.pie-9` | padding-inline-end | `var(--graupl-spacer-9)` |
 | `.pie-10` | padding-inline-end | `var(--graupl-spacer-10)` |
-| `.pie-auto` | padding-inline-end | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 py-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 py-5 ${inlineEndPadding}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 py-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div :class="`bordered border-primary-700 bg-tertiary-200 ${paddingInlineEnd}`">
+          <div class="bg-primary-300 bs-7 is-7"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ inlineEndPadding }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ paddingInlineEnd }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-inline-end-padding">Inline End Padding property</label>
-    <select id="select-inline-end-padding" v-model="inlineEndPadding">
-      <option value="pie-0">Spacer 0</option>
-      <option value="pie-1">Spacer 1</option>
-      <option value="pie-2">Spacer 2</option>
-      <option value="pie-3">Spacer 3</option>
-      <option value="pie-4">Spacer 4</option>
-      <option value="pie-5">Spacer 5</option>
-      <option value="pie-6">Spacer 6</option>
-      <option value="pie-7">Spacer 7</option>
-      <option value="pie-8">Spacer 8</option>
-      <option value="pie-9">Spacer 9</option>
-      <option value="pie-10">Spacer 10</option>
+    <label for="select-padding-inline-end">Padding inline end property</label>
+    <select id="select-padding-inline-end" v-model="paddingInlineEnd">
+      <option value="pie-auto">Auto</option>
+      <option value="pie-0">0</option>
+      <option value="pie-1">1</option>
+      <option value="pie-2">2</option>
+      <option value="pie-3">3</option>
+      <option value="pie-4">4</option>
+      <option value="pie-5">5</option>
+      <option value="pie-6">6</option>
+      <option value="pie-7">7</option>
+      <option value="pie-8">8</option>
+      <option value="pie-9">9</option>
+      <option value="pie-10">10</option>
     </select>
   </div>
 </div>
@@ -771,6 +786,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.pise-auto` | padding-inline | `auto` |
 | `.pise-0` | padding-inline | `var(--graupl-spacer-0)` |
 | `.pise-1` | padding-inline | `var(--graupl-spacer-1)` |
 | `.pise-2` | padding-inline | `var(--graupl-spacer-2)` |
@@ -782,35 +798,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.pise-8` | padding-inline | `var(--graupl-spacer-8)` |
 | `.pise-9` | padding-inline | `var(--graupl-spacer-9)` |
 | `.pise-10` | padding-inline | `var(--graupl-spacer-10)` |
-| `.pise-auto` | padding-inline | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 py-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 py-5 ${inlinePadding}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 py-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div :class="`bordered border-primary-700 bg-tertiary-200 ${paddingInline}`">
+          <div class="bg-primary-300 bs-7 is-7"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ inlinePadding }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ paddingInline }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-inline-padding">Inline Padding property</label>
-    <select id="select-inline-padding" v-model="inlinePadding">
-      <option value="pise-0">Spacer 0</option>
-      <option value="pise-1">Spacer 1</option>
-      <option value="pise-2">Spacer 2</option>
-      <option value="pise-3">Spacer 3</option>
-      <option value="pise-4">Spacer 4</option>
-      <option value="pise-5">Spacer 5</option>
-      <option value="pise-6">Spacer 6</option>
-      <option value="pise-7">Spacer 7</option>
-      <option value="pise-8">Spacer 8</option>
-      <option value="pise-9">Spacer 9</option>
-      <option value="pise-10">Spacer 10</option>
+    <label for="select-padding-inline">Padding inline property</label>
+    <select id="select-padding-inline" v-model="paddingInline">
+      <option value="pise-auto">Auto</option>
+      <option value="pise-0">0</option>
+      <option value="pise-1">1</option>
+      <option value="pise-2">2</option>
+      <option value="pise-3">3</option>
+      <option value="pise-4">4</option>
+      <option value="pise-5">5</option>
+      <option value="pise-6">6</option>
+      <option value="pise-7">7</option>
+      <option value="pise-8">8</option>
+      <option value="pise-9">9</option>
+      <option value="pise-10">10</option>
     </select>
   </div>
 </div>
@@ -819,10 +835,11 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.m-auto` | margin | `auto` |
 | `.m-0` | margin | `var(--graupl-spacer-0)` |
 | `.m-1` | margin | `var(--graupl-spacer-1)` |
 | `.m-2` | margin | `var(--graupl-spacer-2)` |
-| `.m-3` | margin | `var(--graupl-spacer-3)` |
+| `.m-5` | margin | `var(--graupl-spacer-3)` |
 | `.m-4` | margin | `var(--graupl-spacer-4)` |
 | `.m-5` | margin | `var(--graupl-spacer-5)` |
 | `.m-6` | margin | `var(--graupl-spacer-6)` |
@@ -830,15 +847,14 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.m-8` | margin | `var(--graupl-spacer-8)` |
 | `.m-9` | margin | `var(--graupl-spacer-9)` |
 | `.m-10` | margin | `var(--graupl-spacer-10)` |
-| `.m-auto` | margin | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 p-5 ${margin}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div class="bg-tertiary-200">
+          <div :class="`bordered border-primary-700 bg-primary-300 bs-7 is-7 ${margin}`"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
@@ -848,17 +864,18 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
   <div class="input-group">
     <label for="select-margin">Margin property</label>
     <select id="select-margin" v-model="margin">
-      <option value="m-0">Spacer 0</option>
-      <option value="m-1">Spacer 1</option>
-      <option value="m-2">Spacer 2</option>
-      <option value="m-3">Spacer 3</option>
-      <option value="m-4">Spacer 4</option>
-      <option value="m-5">Spacer 5</option>
-      <option value="m-6">Spacer 6</option>
-      <option value="m-7">Spacer 7</option>
-      <option value="m-8">Spacer 8</option>
-      <option value="m-9">Spacer 9</option>
-      <option value="m-10">Spacer 10</option>
+      <option value="m-auto">Auto</option>
+      <option value="m-0">0</option>
+      <option value="m-1">1</option>
+      <option value="m-2">2</option>
+      <option value="m-3">3</option>
+      <option value="m-4">4</option>
+      <option value="m-5">5</option>
+      <option value="m-6">6</option>
+      <option value="m-7">7</option>
+      <option value="m-8">8</option>
+      <option value="m-9">9</option>
+      <option value="m-10">10</option>
     </select>
   </div>
 </div>
@@ -867,6 +884,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.mt-auto` | margin-top | `auto` |
 | `.mt-0` | margin-top | `var(--graupl-spacer-0)` |
 | `.mt-1` | margin-top | `var(--graupl-spacer-1)` |
 | `.mt-2` | margin-top | `var(--graupl-spacer-2)` |
@@ -878,35 +896,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.mt-8` | margin-top | `var(--graupl-spacer-8)` |
 | `.mt-9` | margin-top | `var(--graupl-spacer-9)` |
 | `.mt-10` | margin-top | `var(--graupl-spacer-10)` |
-| `.mt-auto` | margin-top | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 p-5 ${topMargin}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div class="bg-tertiary-200">
+          <div :class="`bordered border-primary-700 bg-primary-300 bs-7 is-7 ${marginTop}`"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ topMargin }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ marginTop }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-top-margin">Top Margin property</label>
-    <select id="select-top-margin" v-model="topMargin">
-      <option value="mt-0">Spacer 0</option>
-      <option value="mt-1">Spacer 1</option>
-      <option value="mt-2">Spacer 2</option>
-      <option value="mt-3">Spacer 3</option>
-      <option value="mt-4">Spacer 4</option>
-      <option value="mt-5">Spacer 5</option>
-      <option value="mt-6">Spacer 6</option>
-      <option value="mt-7">Spacer 7</option>
-      <option value="mt-8">Spacer 8</option>
-      <option value="mt-9">Spacer 9</option>
-      <option value="mt-10">Spacer 10</option>
+    <label for="select-margin-top">Margin top property</label>
+    <select id="select-margin-top" v-model="marginTop">
+      <option value="mt-auto">Auto</option>
+      <option value="mt-0">0</option>
+      <option value="mt-1">1</option>
+      <option value="mt-2">2</option>
+      <option value="mt-3">3</option>
+      <option value="mt-4">4</option>
+      <option value="mt-5">5</option>
+      <option value="mt-6">6</option>
+      <option value="mt-7">7</option>
+      <option value="mt-8">8</option>
+      <option value="mt-9">9</option>
+      <option value="mt-10">10</option>
     </select>
   </div>
 </div>
@@ -915,6 +933,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.mr-auto` | margin-right | `auto` |
 | `.mr-0` | margin-right | `var(--graupl-spacer-0)` |
 | `.mr-1` | margin-right | `var(--graupl-spacer-1)` |
 | `.mr-2` | margin-right | `var(--graupl-spacer-2)` |
@@ -926,35 +945,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.mr-8` | margin-right | `var(--graupl-spacer-8)` |
 | `.mr-9` | margin-right | `var(--graupl-spacer-9)` |
 | `.mr-10` | margin-right | `var(--graupl-spacer-10)` |
-| `.mr-auto` | margin-right | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 p-5 ${rightMargin}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div class="bg-tertiary-200">
+          <div :class="`bordered border-primary-700 bg-primary-300 bs-7 is-7 ${marginRight}`"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ rightMargin }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ marginRight }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-right-margin">Right Margin property</label>
-    <select id="select-right-margin" v-model="rightMargin">
-      <option value="mr-0">Spacer 0</option>
-      <option value="mr-1">Spacer 1</option>
-      <option value="mr-2">Spacer 2</option>
-      <option value="mr-3">Spacer 3</option>
-      <option value="mr-4">Spacer 4</option>
-      <option value="mr-5">Spacer 5</option>
-      <option value="mr-6">Spacer 6</option>
-      <option value="mr-7">Spacer 7</option>
-      <option value="mr-8">Spacer 8</option>
-      <option value="mr-9">Spacer 9</option>
-      <option value="mr-10">Spacer 10</option>
+    <label for="select-margin-right">Margin right property</label>
+    <select id="select-margin-right" v-model="marginRight">
+      <option value="mr-auto">Auto</option>
+      <option value="mr-0">0</option>
+      <option value="mr-1">1</option>
+      <option value="mr-2">2</option>
+      <option value="mr-3">3</option>
+      <option value="mr-4">4</option>
+      <option value="mr-5">5</option>
+      <option value="mr-6">6</option>
+      <option value="mr-7">7</option>
+      <option value="mr-8">8</option>
+      <option value="mr-9">9</option>
+      <option value="mr-10">10</option>
     </select>
   </div>
 </div>
@@ -963,6 +982,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.mb-auto` | margin-bottom | `auto` |
 | `.mb-0` | margin-bottom | `var(--graupl-spacer-0)` |
 | `.mb-1` | margin-bottom | `var(--graupl-spacer-1)` |
 | `.mb-2` | margin-bottom | `var(--graupl-spacer-2)` |
@@ -974,35 +994,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.mb-8` | margin-bottom | `var(--graupl-spacer-8)` |
 | `.mb-9` | margin-bottom | `var(--graupl-spacer-9)` |
 | `.mb-10` | margin-bottom | `var(--graupl-spacer-10)` |
-| `.mb-auto` | margin-bottom | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 p-5 ${bottomMargin}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div class="bg-tertiary-200">
+          <div :class="`bordered border-primary-700 bg-primary-300 bs-7 is-7 ${marginBottom}`"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ bottomMargin }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ marginBottom }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-bottom-margin">Bottom Margin property</label>
-    <select id="select-bottom-margin" v-model="bottomMargin">
-      <option value="mb-0">Spacer 0</option>
-      <option value="mb-1">Spacer 1</option>
-      <option value="mb-2">Spacer 2</option>
-      <option value="mb-3">Spacer 3</option>
-      <option value="mb-4">Spacer 4</option>
-      <option value="mb-5">Spacer 5</option>
-      <option value="mb-6">Spacer 6</option>
-      <option value="mb-7">Spacer 7</option>
-      <option value="mb-8">Spacer 8</option>
-      <option value="mb-9">Spacer 9</option>
-      <option value="mb-10">Spacer 10</option>
+    <label for="select-margin-bottom">Margin bottom property</label>
+    <select id="select-margin-bottom" v-model="marginBottom">
+      <option value="mb-auto">Auto</option>
+      <option value="mb-0">0</option>
+      <option value="mb-1">1</option>
+      <option value="mb-2">2</option>
+      <option value="mb-3">3</option>
+      <option value="mb-4">4</option>
+      <option value="mb-5">5</option>
+      <option value="mb-6">6</option>
+      <option value="mb-7">7</option>
+      <option value="mb-8">8</option>
+      <option value="mb-9">9</option>
+      <option value="mb-10">10</option>
     </select>
   </div>
 </div>
@@ -1011,6 +1031,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.ml-auto` | margin-left | `auto` |
 | `.ml-0` | margin-left | `var(--graupl-spacer-0)` |
 | `.ml-1` | margin-left | `var(--graupl-spacer-1)` |
 | `.ml-2` | margin-left | `var(--graupl-spacer-2)` |
@@ -1022,35 +1043,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.ml-8` | margin-left | `var(--graupl-spacer-8)` |
 | `.ml-9` | margin-left | `var(--graupl-spacer-9)` |
 | `.ml-10` | margin-left | `var(--graupl-spacer-10)` |
-| `.ml-auto` | margin-left | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 p-5 ${leftMargin}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div class="bg-tertiary-200">
+          <div :class="`bordered border-primary-700 bg-primary-300 bs-7 is-7 ${marginLeft}`"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ leftMargin }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ marginLeft }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-left-margin">Left Margin property</label>
-    <select id="select-left-margin" v-model="leftMargin">
-      <option value="ml-0">Spacer 0</option>
-      <option value="ml-1">Spacer 1</option>
-      <option value="ml-2">Spacer 2</option>
-      <option value="ml-3">Spacer 3</option>
-      <option value="ml-4">Spacer 4</option>
-      <option value="ml-5">Spacer 5</option>
-      <option value="ml-6">Spacer 6</option>
-      <option value="ml-7">Spacer 7</option>
-      <option value="ml-8">Spacer 8</option>
-      <option value="ml-9">Spacer 9</option>
-      <option value="ml-10">Spacer 10</option>
+    <label for="select-margin-left">Margin left property</label>
+    <select id="select-margin-left" v-model="marginLeft">
+      <option value="ml-auto">Auto</option>
+      <option value="ml-0">0</option>
+      <option value="ml-1">1</option>
+      <option value="ml-2">2</option>
+      <option value="ml-3">3</option>
+      <option value="ml-4">4</option>
+      <option value="ml-5">5</option>
+      <option value="ml-6">6</option>
+      <option value="ml-7">7</option>
+      <option value="ml-8">8</option>
+      <option value="ml-9">9</option>
+      <option value="ml-10">10</option>
     </select>
   </div>
 </div>
@@ -1059,6 +1080,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.mx-auto` | margin-left, margin-right | `auto` |
 | `.mx-0` | margin-left, margin-right | `var(--graupl-spacer-0)` |
 | `.mx-1` | margin-left, margin-right | `var(--graupl-spacer-1)` |
 | `.mx-2` | margin-left, margin-right | `var(--graupl-spacer-2)` |
@@ -1070,35 +1092,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.mx-8` | margin-left, margin-right | `var(--graupl-spacer-8)` |
 | `.mx-9` | margin-left, margin-right | `var(--graupl-spacer-9)` |
 | `.mx-10` | margin-left, margin-right | `var(--graupl-spacer-10)` |
-| `.mx-auto` | margin-left, margin-right | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 p-5 ${xMargin}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div class="bg-tertiary-200">
+          <div :class="`bordered border-primary-700 bg-primary-300 bs-7 is-7 ${marginX}`"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ xMargin }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ marginX }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-x-margin">X Margin property</label>
-    <select id="select-x-margin" v-model="xMargin">
-      <option value="mx-0">Spacer 0</option>
-      <option value="mx-1">Spacer 1</option>
-      <option value="mx-2">Spacer 2</option>
-      <option value="mx-3">Spacer 3</option>
-      <option value="mx-4">Spacer 4</option>
-      <option value="mx-5">Spacer 5</option>
-      <option value="mx-6">Spacer 6</option>
-      <option value="mx-7">Spacer 7</option>
-      <option value="mx-8">Spacer 8</option>
-      <option value="mx-9">Spacer 9</option>
-      <option value="mx-10">Spacer 10</option>
+    <label for="select-margin-x">Margin X property</label>
+    <select id="select-margin-x" v-model="marginX">
+      <option value="mx-auto">Auto</option>
+      <option value="mx-0">0</option>
+      <option value="mx-1">1</option>
+      <option value="mx-2">2</option>
+      <option value="mx-3">3</option>
+      <option value="mx-4">4</option>
+      <option value="mx-5">5</option>
+      <option value="mx-6">6</option>
+      <option value="mx-7">7</option>
+      <option value="mx-8">8</option>
+      <option value="mx-9">9</option>
+      <option value="mx-10">10</option>
     </select>
   </div>
 </div>
@@ -1107,6 +1129,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.my-auto` | margin-top, margin-bottom | `auto` |
 | `.my-0` | margin-top, margin-bottom | `var(--graupl-spacer-0)` |
 | `.my-1` | margin-top, margin-bottom | `var(--graupl-spacer-1)` |
 | `.my-2` | margin-top, margin-bottom | `var(--graupl-spacer-2)` |
@@ -1118,35 +1141,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.my-8` | margin-top, margin-bottom | `var(--graupl-spacer-8)` |
 | `.my-9` | margin-top, margin-bottom | `var(--graupl-spacer-9)` |
 | `.my-10` | margin-top, margin-bottom | `var(--graupl-spacer-10)` |
-| `.my-auto` | margin-top, margin-bottom | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 p-5 ${yMargin}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div class="bg-tertiary-200">
+          <div :class="`bordered border-primary-700 bg-primary-300 bs-7 is-7 ${marginY}`"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ yMargin }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ marginY }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-y-margin">Y Margin property</label>
-    <select id="select-y-margin" v-model="yMargin">
-      <option value="my-0">Spacer 0</option>
-      <option value="my-1">Spacer 1</option>
-      <option value="my-2">Spacer 2</option>
-      <option value="my-3">Spacer 3</option>
-      <option value="my-4">Spacer 4</option>
-      <option value="my-5">Spacer 5</option>
-      <option value="my-6">Spacer 6</option>
-      <option value="my-7">Spacer 7</option>
-      <option value="my-8">Spacer 8</option>
-      <option value="my-9">Spacer 9</option>
-      <option value="my-10">Spacer 10</option>
+    <label for="select-margin-y">Margin Y property</label>
+    <select id="select-margin-y" v-model="marginY">
+      <option value="my-auto">Auto</option>
+      <option value="my-0">0</option>
+      <option value="my-1">1</option>
+      <option value="my-2">2</option>
+      <option value="my-3">3</option>
+      <option value="my-4">4</option>
+      <option value="my-5">5</option>
+      <option value="my-6">6</option>
+      <option value="my-7">7</option>
+      <option value="my-8">8</option>
+      <option value="my-9">9</option>
+      <option value="my-10">10</option>
     </select>
   </div>
 </div>
@@ -1155,6 +1178,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.mbs-auto` | margin-block-start | `auto` |
 | `.mbs-0` | margin-block-start | `var(--graupl-spacer-0)` |
 | `.mbs-1` | margin-block-start | `var(--graupl-spacer-1)` |
 | `.mbs-2` | margin-block-start | `var(--graupl-spacer-2)` |
@@ -1166,43 +1190,45 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.mbs-8` | margin-block-start | `var(--graupl-spacer-8)` |
 | `.mbs-9` | margin-block-start | `var(--graupl-spacer-9)` |
 | `.mbs-10` | margin-block-start | `var(--graupl-spacer-10)` |
-| `.mbs-auto` | margin-block-start | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 px-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 px-5 ${blockStartMargin}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 px-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div class="bg-tertiary-200">
+          <div :class="`bordered border-primary-700 bg-primary-300 bs-7 is-7 ${marginBlockStart}`"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ blockStartMargin }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ marginBlockStart }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-block-start-margin">Block Start Margin property</label>
-    <select id="select-block-start-margin" v-model="blockStartMargin">
-      <option value="mbs-0">Spacer 0</option>
-      <option value="mbs-1">Spacer 1</option>
-      <option value="mbs-2">Spacer 2</option>
-      <option value="mbs-3">Spacer 3</option>
-      <option value="mbs-4">Spacer 4</option>
-      <option value="mbs-5">Spacer 5</option>
-      <option value="mbs-6">Spacer 6</option>
-      <option value="mbs-7">Spacer 7</option>
-      <option value="mbs-8">Spacer 8</option>
-      <option value="mbs-9">Spacer 9</option>
-      <option value="mbs-10">Spacer 10</option>
+    <label for="select-margin-block-start">Margin block start property</label>
+    <select id="select-margin-block-start" v-model="marginBlockStart">
+      <option value="mbs-auto">Auto</option>
+      <option value="mbs-0">0</option>
+      <option value="mbs-1">1</option>
+      <option value="mbs-2">2</option>
+      <option value="mbs-3">3</option>
+      <option value="mbs-4">4</option>
+      <option value="mbs-5">5</option>
+      <option value="mbs-6">6</option>
+      <option value="mbs-7">7</option>
+      <option value="mbs-8">8</option>
+      <option value="mbs-9">9</option>
+      <option value="mbs-10">10</option>
     </select>
   </div>
 </div>
+
 
 ## Margin Block End
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.mbe-auto` | margin-block-end | `auto` |
 | `.mbe-0` | margin-block-end | `var(--graupl-spacer-0)` |
 | `.mbe-1` | margin-block-end | `var(--graupl-spacer-1)` |
 | `.mbe-2` | margin-block-end | `var(--graupl-spacer-2)` |
@@ -1214,35 +1240,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.mbe-8` | margin-block-end | `var(--graupl-spacer-8)` |
 | `.mbe-9` | margin-block-end | `var(--graupl-spacer-9)` |
 | `.mbe-10` | margin-block-end | `var(--graupl-spacer-10)` |
-| `.mbe-auto` | margin-block-end | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 px-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 px-5 ${blockEndMargin}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 px-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div class="bg-tertiary-200">
+          <div :class="`bordered border-primary-700 bg-primary-300 bs-7 is-7 ${marginBlockEnd}`"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ blockEndMargin }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ marginBlockEnd }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-block-end-margin">Block End Margin property</label>
-    <select id="select-block-end-margin" v-model="blockEndMargin">
-      <option value="mbe-0">Spacer 0</option>
-      <option value="mbe-1">Spacer 1</option>
-      <option value="mbe-2">Spacer 2</option>
-      <option value="mbe-3">Spacer 3</option>
-      <option value="mbe-4">Spacer 4</option>
-      <option value="mbe-5">Spacer 5</option>
-      <option value="mbe-6">Spacer 6</option>
-      <option value="mbe-7">Spacer 7</option>
-      <option value="mbe-8">Spacer 8</option>
-      <option value="mbe-9">Spacer 9</option>
-      <option value="mbe-10">Spacer 10</option>
+    <label for="select-margin-block-end">Margin block end property</label>
+    <select id="select-margin-block-end" v-model="marginBlockEnd">
+      <option value="mbe-auto">Auto</option>
+      <option value="mbe-0">0</option>
+      <option value="mbe-1">1</option>
+      <option value="mbe-2">2</option>
+      <option value="mbe-3">3</option>
+      <option value="mbe-4">4</option>
+      <option value="mbe-5">5</option>
+      <option value="mbe-6">6</option>
+      <option value="mbe-7">7</option>
+      <option value="mbe-8">8</option>
+      <option value="mbe-9">9</option>
+      <option value="mbe-10">10</option>
     </select>
   </div>
 </div>
@@ -1251,6 +1277,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.mbse-auto` | margin-block | `auto` |
 | `.mbse-0` | margin-block | `var(--graupl-spacer-0)` |
 | `.mbse-1` | margin-block | `var(--graupl-spacer-1)` |
 | `.mbse-2` | margin-block | `var(--graupl-spacer-2)` |
@@ -1262,35 +1289,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.mbse-8` | margin-block | `var(--graupl-spacer-8)` |
 | `.mbse-9` | margin-block | `var(--graupl-spacer-9)` |
 | `.mbse-10` | margin-block | `var(--graupl-spacer-10)` |
-| `.mbse-auto` | margin-block | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 px-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 px-5 ${blockMargin}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 px-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div class="bg-tertiary-200">
+          <div :class="`bordered border-primary-700 bg-primary-300 bs-7 is-7 ${marginBlock}`"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ blockMargin }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ marginBlock }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-block-margin">Block Margin property</label>
-    <select id="select-block-margin" v-model="blockMargin">
-      <option value="mbse-0">Spacer 0</option>
-      <option value="mbse-1">Spacer 1</option>
-      <option value="mbse-2">Spacer 2</option>
-      <option value="mbse-3">Spacer 3</option>
-      <option value="mbse-4">Spacer 4</option>
-      <option value="mbse-5">Spacer 5</option>
-      <option value="mbse-6">Spacer 6</option>
-      <option value="mbse-7">Spacer 7</option>
-      <option value="mbse-8">Spacer 8</option>
-      <option value="mbse-9">Spacer 9</option>
-      <option value="mbse-10">Spacer 10</option>
+    <label for="select-margin-block">Margin block property</label>
+    <select id="select-margin-block" v-model="marginBlock">
+      <option value="mbse-auto">Auto</option>
+      <option value="mbse-0">0</option>
+      <option value="mbse-1">1</option>
+      <option value="mbse-2">2</option>
+      <option value="mbse-3">3</option>
+      <option value="mbse-4">4</option>
+      <option value="mbse-5">5</option>
+      <option value="mbse-6">6</option>
+      <option value="mbse-7">7</option>
+      <option value="mbse-8">8</option>
+      <option value="mbse-9">9</option>
+      <option value="mbse-10">10</option>
     </select>
   </div>
 </div>
@@ -1299,6 +1326,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.mis-auto` | margin-inline-start | `auto` |
 | `.mis-0` | margin-inline-start | `var(--graupl-spacer-0)` |
 | `.mis-1` | margin-inline-start | `var(--graupl-spacer-1)` |
 | `.mis-2` | margin-inline-start | `var(--graupl-spacer-2)` |
@@ -1310,35 +1338,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.mis-8` | margin-inline-start | `var(--graupl-spacer-8)` |
 | `.mis-9` | margin-inline-start | `var(--graupl-spacer-9)` |
 | `.mis-10` | margin-inline-start | `var(--graupl-spacer-10)` |
-| `.mis-auto` | margin-inline-start | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 p-5 ${inlineStartMargin}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div class="bg-tertiary-200">
+          <div :class="`bordered border-primary-700 bg-primary-300 bs-7 is-7 ${marginInlineStart}`"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ inlineStartMargin }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ marginInlineStart }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-inline-start-margin">Inline Start Margin property</label>
-    <select id="select-inline-start-margin" v-model="inlineStartMargin">
-      <option value="mis-0">Spacer 0</option>
-      <option value="mis-1">Spacer 1</option>
-      <option value="mis-2">Spacer 2</option>
-      <option value="mis-3">Spacer 3</option>
-      <option value="mis-4">Spacer 4</option>
-      <option value="mis-5">Spacer 5</option>
-      <option value="mis-6">Spacer 6</option>
-      <option value="mis-7">Spacer 7</option>
-      <option value="mis-8">Spacer 8</option>
-      <option value="mis-9">Spacer 9</option>
-      <option value="mis-10">Spacer 10</option>
+    <label for="select-margin-inline-start">Margin inline start property</label>
+    <select id="select-margin-inline-start" v-model="marginInlineStart">
+      <option value="mis-auto">Auto</option>
+      <option value="mis-0">0</option>
+      <option value="mis-1">1</option>
+      <option value="mis-2">2</option>
+      <option value="mis-3">3</option>
+      <option value="mis-4">4</option>
+      <option value="mis-5">5</option>
+      <option value="mis-6">6</option>
+      <option value="mis-7">7</option>
+      <option value="mis-8">8</option>
+      <option value="mis-9">9</option>
+      <option value="mis-10">10</option>
     </select>
   </div>
 </div>
@@ -1347,6 +1375,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.mie-auto` | margin-inline-end | `auto` |
 | `.mie-0` | margin-inline-end | `var(--graupl-spacer-0)` |
 | `.mie-1` | margin-inline-end | `var(--graupl-spacer-1)` |
 | `.mie-2` | margin-inline-end | `var(--graupl-spacer-2)` |
@@ -1358,35 +1387,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.mie-8` | margin-inline-end | `var(--graupl-spacer-8)` |
 | `.mie-9` | margin-inline-end | `var(--graupl-spacer-9)` |
 | `.mie-10` | margin-inline-end | `var(--graupl-spacer-10)` |
-| `.mie-auto` | margin-inline-end | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 p-5 ${inlineEndMargin}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div class="bg-tertiary-200">
+          <div :class="`bordered border-primary-700 bg-primary-300 bs-7 is-7 ${marginInlineEnd}`"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ inlineEndMargin }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ marginInlineEnd }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-inline-end-margin">Inline End Margin property</label>
-    <select id="select-inline-end-margin" v-model="inlineEndMargin">
-      <option value="mie-0">Spacer 0</option>
-      <option value="mie-1">Spacer 1</option>
-      <option value="mie-2">Spacer 2</option>
-      <option value="mie-3">Spacer 3</option>
-      <option value="mie-4">Spacer 4</option>
-      <option value="mie-5">Spacer 5</option>
-      <option value="mie-6">Spacer 6</option>
-      <option value="mie-7">Spacer 7</option>
-      <option value="mie-8">Spacer 8</option>
-      <option value="mie-9">Spacer 9</option>
-      <option value="mie-10">Spacer 10</option>
+    <label for="select-margin-inline-end">Margin inline end property</label>
+    <select id="select-margin-inline-end" v-model="marginInlineEnd">
+      <option value="mie-auto">Auto</option>
+      <option value="mie-0">0</option>
+      <option value="mie-1">1</option>
+      <option value="mie-2">2</option>
+      <option value="mie-3">3</option>
+      <option value="mie-4">4</option>
+      <option value="mie-5">5</option>
+      <option value="mie-6">6</option>
+      <option value="mie-7">7</option>
+      <option value="mie-8">8</option>
+      <option value="mie-9">9</option>
+      <option value="mie-10">10</option>
     </select>
   </div>
 </div>
@@ -1395,6 +1424,7 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 
 | Class Name | Property | Value |
 | --- | --- | --- |
+| `.mise-auto` | margin-inline | `auto` |
 | `.mise-0` | margin-inline | `var(--graupl-spacer-0)` |
 | `.mise-1` | margin-inline | `var(--graupl-spacer-1)` |
 | `.mise-2` | margin-inline | `var(--graupl-spacer-2)` |
@@ -1406,35 +1436,35 @@ The spacing utilities provide a set of classes to adjust the `gap`, `row-gap`, `
 | `.mise-8` | margin-inline | `var(--graupl-spacer-8)` |
 | `.mise-9` | margin-inline | `var(--graupl-spacer-9)` |
 | `.mise-10` | margin-inline | `var(--graupl-spacer-10)` |
-| `.mise-auto` | margin-inline | `auto` |
 
 <div class="example">
   <div class="example-container">
     <div class="example-display">
-      <div class="display-grid h-full g-3" style="grid-template-columns: repeat(3, min-content); grid-template-rows: min-content;">
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
-        <div :class="`bordered border-primary-700 bg-primary-300 p-5 ${inlineMargin}`"></div>
-        <div class="bordered border-primary-700 bg-primary-300 p-5"></div>
+      <div class="display-flex is-fit-content bs-fit-content">
+        <div class="bg-tertiary-200">
+          <div :class="`bordered border-primary-700 bg-primary-300 bs-7 is-7 ${marginInline}`"></div>
+        </div>
       </div>
     </div>
     <div class="example-classes">
-      <code>&lt;div class="{{ inlineMargin }}"&gt;&lt;/div&gt;</code>
+      <code>&lt;div class="{{ marginInline }}"&gt;&lt;/div&gt;</code>
     </div>
   </div>
   <div class="input-group">
-    <label for="select-inline-margin">Inline Margin property</label>
-    <select id="select-inline-margin" v-model="inlineMargin">
-      <option value="mise-0">Spacer 0</option>
-      <option value="mise-1">Spacer 1</option>
-      <option value="mise-2">Spacer 2</option>
-      <option value="mise-3">Spacer 3</option>
-      <option value="mise-4">Spacer 4</option>
-      <option value="mise-5">Spacer 5</option>
-      <option value="mise-6">Spacer 6</option>
-      <option value="mise-7">Spacer 7</option>
-      <option value="mise-8">Spacer 8</option>
-      <option value="mise-9">Spacer 9</option>
-      <option value="mise-10">Spacer 10</option>
+    <label for="select-margin-inline">Margin inline property</label>
+    <select id="select-margin-inline" v-model="marginInline">
+      <option value="mise-auto">Auto</option>
+      <option value="mise-0">0</option>
+      <option value="mise-1">1</option>
+      <option value="mise-2">2</option>
+      <option value="mise-3">3</option>
+      <option value="mise-4">4</option>
+      <option value="mise-5">5</option>
+      <option value="mise-6">6</option>
+      <option value="mise-7">7</option>
+      <option value="mise-8">8</option>
+      <option value="mise-9">9</option>
+      <option value="mise-10">10</option>
     </select>
   </div>
 </div>


### PR DESCRIPTION
## Description

Want to give an example of how to make the docs more useful in what they're trying to portray in the examples as well as clean up some of the code.

A couple of notes:

- The variable naming was off from what it should be. If we have something controlling the `margin-top` property, let's call it `marginTop` to unify the naming and make it easier to just intuitively know what variable needs to be used. I made this change for the labels as well.
- I made `auto` the default _and_ moved it up to the top (I think it makes sense that way, but we'll see how it works in practice).
- Removed the word "Spacer" from all the options. The classes themselves are just `-1`, `-2`, `-3`, etc. so the values should reflect that.
- Cleaned up some of the grid and container styling (this is just to reflect that we now _have_ grid classes to use instead of manual styles).
- Reworked _how_ we show these as examples. The initial examples had things resizing as you changed values _and_ had objects awkwardly change proportions. I've standardized all the sizing and make sure the actual aspect of the element that's changing is highlighted (e.g. showing the gap area in pink so it stands out).

@jlbdash Take a look at this and make sure you apply some of the same logic to other examples. We want to highlight exactly what the utility class it doing, not just show a thing changing on the page and hope users understand.